### PR TITLE
spread.yaml: updates for UC26

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -19,3 +19,4 @@ jobs:
         with:
           # TODO: remove this filter when launchpad riscv64 builds are stable
           architectures: arm64,amd64,armhf
+          spread_suites: "openstack:"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,3 +15,4 @@ jobs:
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         uses: canonical/system-snaps-cicd-tools/action-test@main
+        spread_suites: "openstack:"

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,7 +26,7 @@ environment:
   TESTSLIB: $PROJECT_PATH/cicd/snapd-lib
   SYSTEMSNAPSTESTLIB: $PROJECT_PATH/cicd/lib
   TESTSTOOLS: $PROJECT_PATH/cicd/snapd-lib/tools
-  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools
+  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools:/usr/lib/python
   TESTSTMP: /var/tmp/snapd-tools
   REUSE_SNAPD: 0
   SRU_VALIDATION: 0
@@ -37,8 +37,42 @@ environment:
   KERNEL_CHANNEL: '$(HOST: echo "${SPREAD_KERNEL_CHANNEL:-edge}")'
   GADGET_CHANNEL: '$(HOST: echo "${SPREAD_GADGET_CHANNEL:-edge}")'
   SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
+  SNAPD_WORK_DIR: '$(HOST: echo "${SPREAD_SNAPD_WORK_DIR:-/var/tmp/work-dir}")'
+  SNAPD_USE_PROXY: '$(HOST: echo "${SPREAD_SNAPD_USE_PROXY:-}")'
+  HTTP_PROXY: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  http_proxy: '$(HOST: echo "$SPREAD_HTTP_PROXY")'
+  HTTPS_PROXY: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  https_proxy: '$(HOST: echo "$SPREAD_HTTPS_PROXY")'
+  NO_PROXY: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
+  no_proxy: '$(HOST: echo "${SPREAD_NO_PROXY:-127.0.0.1}")'
 
 backends:
+  openstack:
+    key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+    plan: shared.xsmall
+    halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.96.0/21:5000]
+    volume-auto-delete: true
+    environment: &openstack-env
+        SNAPD_USE_PROXY: 'true'
+        HTTP_PROXY: 'http://egress.ps7.internal:3128'
+        HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+        http_proxy: 'http://egress.ps7.internal:3128'
+        https_proxy: 'http://egress.ps7.internal:3128'
+        no_proxy: '127.0.0.1,127.0.0.53,localhost'
+        NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+        NTP_SERVER: 'ntp.ps7.internal'
+    systems: &openstack-systems
+      - ubuntu-core-26-64:
+          image: snapd-spread/ubuntu-26.04-64-uefi
+          workers: 1
+    prepare: |
+      # Builds UC image on top of classic 26.04
+      "$TESTSLIB"/prepare-restore.sh --prepare-suite
+
   openstack-dev:
     type: openstack
     key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
@@ -49,30 +83,22 @@ backends:
     proxy: ingress-haproxy.ps7.canonical.com
     cidr-port-rel: [10.151.54.0/24:4000]
     volume-auto-delete: true
-    environment:
-      SNAPD_USE_PROXY: 'true'
-      HTTP_PROXY: 'http://egress.ps7.internal:3128'
-      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
-      http_proxy: 'http://egress.ps7.internal:3128'
-      https_proxy: 'http://egress.ps7.internal:3128'
-      no_proxy: '127.0.0.1,127.0.0.53,localhost'
-      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
-      NTP_SERVER: 'ntp.ps7.internal'
-    systems:
-      - ubuntu-core-26-64:
-          image: ubuntu-26.04-64
-          workers: 8
-          storage: 20G
+    environment: *openstack-env
+    systems: *openstack-systems
     prepare: |
       # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
 
   qemu:
     memory: 4G
+    prepare: |
+      # Builds UC image on top of classic 26.04
+      "$TESTSLIB"/prepare-restore.sh --prepare-suite
     systems:
       - ubuntu-core-26-64:
-          username: test
-          password: test
+          image: ubuntu-26.04-64-uefi
+          username: ubuntu
+          password: ubuntu
           bios: uefi
 
 prepare: |
@@ -100,7 +126,8 @@ prepare: |
 
 prepare-each: |
   # install the normal from store first to get auto-connected on plugs
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable no
+  # TODO: get back to stable risk when available
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/beta no
   
   # now install the one built by tests
   snap install --dangerous "${PROJECT_PATH}/${SNAP_NAME}"*_amd64.snap


### PR DESCRIPTION
- add openstack backend and use it for the github actions
- explicitely add python to PATH (hidden in UC26 core snap)
- use UC reflashing method for QEMU backend
- fetch snap from the beta channel until it is available in stable